### PR TITLE
Tweaks for on premise and using http

### DIFF
--- a/PSHEATAPI/PSHEATAPI.psm1
+++ b/PSHEATAPI/PSHEATAPI.psm1
@@ -30,7 +30,9 @@ if ((Test-Path $PSScriptRoot\data\config.json) -and (Test-Path $PSScriptRoot\dat
         
         } catch {
         
-            Write-Warning -Message 'unable to initiate web service proxy connection, check cached credentials or manually rerun Connect-HEATProxy'
+            Write-Warning -Message 'Unable to initiate web service proxy connection, check cached credentials or manually rerun Connect-HEATProxy.'
         
         }    
+} else {
+    Write-Warning -Message 'Please manually run Connect-HEATProxy or set the config.json file and run Set-CachedCredentials.'
 }

--- a/PSHEATAPI/PSHEATAPI.psm1
+++ b/PSHEATAPI/PSHEATAPI.psm1
@@ -18,16 +18,19 @@ $private = @(Get-ChildItem -Path "$PSScriptRoot\Private" -Filter '*.ps1' -Recurs
 Export-ModuleMember -Function $public.BaseName
 
 # automatically connect to the service when the module is loaded
-try {
-
-    $config = Get-Content -Path $PSScriptRoot\data\config.json | ConvertFrom-Json
-
-    $credentials = [pscredential](Import-Clixml -Path "$PSScriptRoot\data\cachedCredentials")
-
-    Connect-HEATProxy -TenantID $config.tenantId -Role $config.defaultRole -Credential $credentials | Out-Null
-
-} catch {
-
-    Write-Warning -Message 'unable to initiate web service proxy connection, check cached credentials or manually rerun Connect-HEATProxy'
-
+# Wrapped around Test-Path for config.json and cachedCredentials otherwise Module displays error on load.
+if ((Test-Path $PSScriptRoot\data\config.json) -and (Test-Path $PSScriptRoot\data\cachedCredentials)) {
+    try {
+        
+            $config = Get-Content -Path $PSScriptRoot\data\config.json | ConvertFrom-Json
+        
+            $credentials = [pscredential](Import-Clixml -Path "$PSScriptRoot\data\cachedCredentials")
+        
+            Connect-HEATProxy -TenantID $config.tenantId -Role $config.defaultRole -Credential $credentials | Out-Null
+        
+        } catch {
+        
+            Write-Warning -Message 'unable to initiate web service proxy connection, check cached credentials or manually rerun Connect-HEATProxy'
+        
+        }    
 }

--- a/PSHEATAPI/Public/Connection/Connect-HEATProxy.ps1
+++ b/PSHEATAPI/Public/Connection/Connect-HEATProxy.ps1
@@ -93,6 +93,13 @@ function Connect-HEATProxy {
         }
 
     }
+    if (-not $NoSSL) {
+        if ($script:HEATCONNECTION.NoSSL) {
+            $NoSSL = $true
+        } else {
+            $NoSSL = $false
+        }
+    }
     if ($NoSSL) {
         $webProxyUri = "http://$TenantID/HEAT/ServiceAPI/FRSHEATIntegration.asmx?wsdl"  # Kreloc needed /HEAT/ in his environment, not sure how true that is for other on prem.
     } else {
@@ -126,6 +133,8 @@ function Connect-HEATProxy {
     $script:HEATCONNECTION | Add-Member -NotePropertyName 'tenantId' -NotePropertyValue $TenantID
     # add the role to the connection proxy so we can easily reference it to renew when session expires
     $script:HEATCONNECTION | Add-Member -NotePropertyName 'role'     -NotePropertyValue $Role
+    # add if NoSSL was used
+    $script:HEATCONNECTION | Add-Member -NotePropertyName 'NoSSL' -NotePropertyValue $NoSSL
 
     Write-Verbose -Message "connection to $webProxyUri succeeded"
 

--- a/PSHEATAPI/Public/Connection/Connect-HEATProxy.ps1
+++ b/PSHEATAPI/Public/Connection/Connect-HEATProxy.ps1
@@ -28,9 +28,9 @@
     the Get-Credential pop-up window.
 
     .EXAMPLE
-    Connect-HEATProxy -TenantID "HDJNU01" -Role 'Admin' -Credential (Get-Credential) -NoSSL
+    Connect-HEATProxy -TenantID "HDSRV01" -Role 'Admin' -Credential (Get-Credential) -NoSSL
 
-    Opens a connection to HDJNU01, under the Admin role using the credentials provided and going to an http endpoint.
+    Opens a connection to HDSRV01, under the Admin role using the credentials provided and going to an http endpoint.
     .NOTES
     Please remember that cached credentials are only available to the user that cached them, from the device that
     they were cached on. Take this into account when setting up scheduled tasks or when testing in your own lab.

--- a/PSHEATAPI/Public/Connection/Connect-HEATProxy.ps1
+++ b/PSHEATAPI/Public/Connection/Connect-HEATProxy.ps1
@@ -14,6 +14,8 @@
     will need to provide your own credentials via Get-Credential. The username is just your network username (i.e.
     'jdoe') and your current network password. Ensure that you are passing an appropriate -Role attached to that
     account.
+    .PARAMETER NoSSL
+    Use this to connect to a HEAT server using http.
     .EXAMPLE
     PS C:\>Connect-HEATProxy -TenantID 'my.tenant.id' -Role 'Admin II'
 
@@ -24,6 +26,11 @@
 
     Opens a connection to 'my.tenant.id', under the 'Service Desk Analyst' role using the credentials provided from
     the Get-Credential pop-up window.
+
+    .EXAMPLE
+    Connect-HEATProxy -TenantID "HDJNU01" -Role 'Admin' -Credential (Get-Credential) -NoSSL
+
+    Opens a connection to HDJNU01, under the Admin role using the credentials provided and going to an http endpoint.
     .NOTES
     Please remember that cached credentials are only available to the user that cached them, from the device that
     they were cached on. Take this into account when setting up scheduled tasks or when testing in your own lab.
@@ -35,10 +42,13 @@ function Connect-HEATProxy {
         [Parameter(Position = 0)]
         [string]$TenantID,
         [Parameter(Position = 1)]
-        [ValidateSet('Admin II', 'Inventory Manager', 'Report Manager', 'Self Service', 'Service Desk Analyst')]
+        [ValidateSet('Admin','Admin II', 'Inventory Manager', 'Report Manager', 'Self Service', 'Service Desk Analyst')]
         [string]$Role,
         [Parameter(Position = 2)]
-        [pscredential]$Credential
+        [pscredential]$Credential,
+        [Parameter()]
+        [switch]
+        $NoSSL
     )
 
     # validate all our parameters are either provided or cached
@@ -83,8 +93,11 @@ function Connect-HEATProxy {
         }
 
     }
-
-    $webProxyUri = "https://$TenantID/ServiceAPI/FRSHEATIntegration.asmx?wsdl"
+    if ($NoSSL) {
+        $webProxyUri = "http://$TenantID/HEAT/ServiceAPI/FRSHEATIntegration.asmx?wsdl"  # Kreloc needed /HEAT/ in his environment, not sure how true that is for other on prem.
+    } else {
+        $webProxyUri = "https://$TenantID/ServiceAPI/FRSHEATIntegration.asmx?wsdl"        
+    }    
 
     # this just creates the proxy object we'll call, it does NOT connect to the service!
     $script:HEATPROXY = New-WebServiceProxy -Uri $webProxyUri -Namespace "WebServiceProxy" -Class "HEAT"

--- a/PSHEATAPI/Public/Metadata/Get-HEATSchemaForObject.ps1
+++ b/PSHEATAPI/Public/Metadata/Get-HEATSchemaForObject.ps1
@@ -89,11 +89,8 @@ function Get-HEATSchemaForObject {
             opposed to the raw text of the xml.
         #>
         # $response
-        if ($response -match '<?xml version="1.0"') {
             [xml]$response
-        } else {
-            $response
-        }
+
 
     }
 

--- a/PSHEATAPI/Public/Metadata/Get-HEATSchemaForObject.ps1
+++ b/PSHEATAPI/Public/Metadata/Get-HEATSchemaForObject.ps1
@@ -84,7 +84,16 @@ function Get-HEATSchemaForObject {
             System.Web.Services.Protocols.SoapException: Server was unable to process request. ---> System.Exception:
             Object not found' if you provided an invalid object type (not specified in GetAllAllowedObjectNames)
         #>
-        $response
+        <#
+            This response if it is xml really should be cast into xml in PowerShell as it is an object that can be navigated
+            opposed to the raw text of the xml.
+        #>
+        # $response
+        if ($response -match '<?xml version="1.0"') {
+            [xml]$response
+        } else {
+            $response
+        }
 
     }
 


### PR DESCRIPTION
Tweaked some of the functions to allow for using http and to not get an error about not finding the config file when the module is imported. 
Added NoSSL parameter to Connect-HEATProxy.
Added NoSSL to $script:HEATCONNECTION so that the reconnect calls will work.
Added xml casting to the response provided by Get-HEATSchemaForObject.



